### PR TITLE
✨ Add: 공통 버튼 컴포넌트 생성

### DIFF
--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -18,7 +18,7 @@ const Button = ({
     primary:
       'text-white bg-deep-mint hover:bg-darkmint hover:border-darkmint border-transparent',
     outline:
-      'text-deep-mint border-2 border-deep-mint hover:bg-darkmint hover:border-darkmint hover:text-white',
+      'text-deep-mint bg-white border-2 border-deep-mint hover:bg-darkmint hover:border-darkmint hover:text-white',
   };
   return (
     <button

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const Button = ({
+  children,
+  onClick,
+  type = 'button',
+  variant = 'primary',
+  size = 'medium',
+  disabled = false,
+}) => {
+  const baseUrl = 'transition-all leading-none duration-200 rounded-full ';
+  const sizeStyle = {
+    small: 'px-3 py-1 text-caption min-w-[80px] h-[20px]',
+    medium: 'px-4 py-2 text-text-md min-w-[100px] h-[40px]',
+    large: 'px-6 py-3 text-title-sm min-w-[210px] h-[50px]',
+  };
+  const variantStyles = {
+    primary:
+      'text-white bg-deep-mint hover:bg-darkmint hover:border-darkmint border-transparent',
+    outline:
+      'text-deep-mint border-2 border-deep-mint hover:bg-darkmint hover:border-darkmint hover:text-white',
+  };
+  return (
+    <button
+      type={type}
+      className={`${baseUrl} ${sizeStyle[size]} ${variantStyles[variant]}`}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #11

<br>

## 📝 작업 내용

> 공통 버튼 컴포넌트

<br>

## 🖼 스크린샷

<br>
<img width="263" alt="스크린샷 2025-02-27 오후 12 38 13" src="https://github.com/user-attachments/assets/ed830a4e-0810-466b-9f45-8742e225e271" />


## 💬리뷰 요구사항

> 버튼 props에 추가적으로 들어갈 것이 있을까요?