### PR TITLE
🎨 Style: 버튼 컴포넌트의 크기 스타일에서 높이 속성 제거 #11

### DIFF
--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -10,9 +10,9 @@ const Button = ({
 }) => {
   const baseUrl = 'transition-all leading-none duration-200 rounded-full ';
   const sizeStyle = {
-    small: 'px-3 py-1 text-caption min-w-[80px] h-[20px]',
-    medium: 'px-4 py-2 text-text-md min-w-[100px] h-[40px]',
-    large: 'px-6 py-3 text-title-sm min-w-[210px] h-[50px]',
+    small: 'px-3 py-1 text-caption min-w-[80px]',
+    medium: 'px-4 py-2 text-text-md min-w-[100px]',
+    large: 'px-6 py-3 text-title-sm min-w-[210px]',
   };
   const variantStyles = {
     primary:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #11

<br>

## 📝 작업 내용

> 버튼 컴포넌트 높이 제거 - 텍스트가 일부 내려가는 현상 발생

<br>

## 🖼 스크린샷
<img width="144" alt="스크린샷 2025-02-27 오후 8 08 40" src="https://github.com/user-attachments/assets/7058b524-155b-4ca6-9b4b-1a1005217830" />
<img width="95" alt="스크린샷 2025-02-27 오후 8 10 19" src="https://github.com/user-attachments/assets/5b7449a9-c560-4b75-aa51-347a4f35b775" />



<br>

## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?